### PR TITLE
Make contributing to docs easier

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,6 +189,9 @@ const output = {
 							const sidebarItems = await defaultSidebarItemsGenerator(args);
 							return sidebarItems;
 						},
+					editUrl: ({ docPath }) => {
+						return `https://holocron.so/github/pr/APHGames/web/main/editor/docs/${docPath}`
+					},
 				},
 				blog: {
 					showReadingTime: true,


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/APHGames/web/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb